### PR TITLE
Configure git to use gpg for signing

### DIFF
--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -28,6 +28,7 @@
 [user]
 	name = Dan Schultz
 	email = slifty@gmail.com
+	signingkey = 435D43717D1B7679F919C1F5E0CA48C6D625499F
 [alias]
 	cleanup = "!f() { declare -a BASE_BRANCH_NAMES_DESC_PRIORTY=("dev" "development" "main" "master") && for i in "${BASE_BRANCH_NAMES_DESC_PRIORTY[@]}"; do if [ -z "$BASE_BRANCH" ]; then if $(git show-ref --verify --quiet refs/heads/$i); then BASE_BRANCH="$i"; fi; fi; done; BRANCH_NAMES_STRING="${BASE_BRANCH_NAMES_DESC_PRIORTY[@]}"; GREP_PARAMS="${BRANCH_NAMES_STRING// /\\\\|}\\\\\\|\\\\*"; git branch --merged ${1-$BASE_BRANCH} | grep -v "$GREP_PARAMS" | xargs -n 1 git branch -d; }; f"
 	brebase = "!f() { declare -a BASE_BRANCH_NAMES_DESC_PRIORTY=("dev" "development" "main" "master") && for i in "${BASE_BRANCH_NAMES_DESC_PRIORTY[@]}"; do if [ -z "$BASE_BRANCH" ]; then if $(git show-ref --verify --quiet refs/heads/$i); then BASE_BRANCH="$i"; fi; fi; done; git rebase -i `git merge-base HEAD ${1-$BASE_BRANCH}`; }; f"
@@ -40,3 +41,5 @@
 	autoSquash = true
 [init]
 	defaultBranch = main
+[commit]
+	gpgsign = true

--- a/gpg/env.zsh
+++ b/gpg/env.zsh
@@ -1,0 +1,3 @@
+# We want GPG to prompt for passphrases when needed, even if the call is coming from
+# inside another process.
+export GPG_TTY=$(tty)


### PR DESCRIPTION
This PR:

1. Configures git to use a signing key to sign commits
2. Configures gpg to use tty (which means it prompts when called via a script)

It's on the user to configure their git remote to care at all about signing (github and gitlab both have helpful instructions)